### PR TITLE
Added missing break statements to swtich statement

### DIFF
--- a/src/main/java/net/machinemuse/numina/network/MusePacketHandler.java
+++ b/src/main/java/net/machinemuse/numina/network/MusePacketHandler.java
@@ -76,6 +76,7 @@ public final class MusePacketHandler extends MessageToMessageCodec<FMLProxyPacke
                     MusePackager packagerServer = this.packagers.get(packetType);
                     MusePacket packetServer = packagerServer.read(data, player);
                     packetServer.handleServer(player);
+                    break;
 
                 case CLIENT:
                     player = this.getClientPlayer();
@@ -83,6 +84,7 @@ public final class MusePacketHandler extends MessageToMessageCodec<FMLProxyPacke
                     MusePackager packagerClient = this.packagers.get(packetType);
                     MusePacket packetClient = packagerClient.read(data, player);
                     packetClient.handleClient(player);
+                    break;
             }
         }catch (Exception exception) {
             MuseLogger.logException("PROBLEM READING PACKET IN DECODE STEP D:", exception);


### PR DESCRIPTION
Clients are getting kicked with the following error due to the fall through from the `SERVER` to the `CLIENT` due to the missing break statement:

```
[08:20:38] [Server thread/ERROR] [FML/]: There was a critical exception handling a packet on channel Numina
java.lang.NoSuchMethodError: net.machinemuse.numina.network.MusePacketHandler.getClientPlayer()Lnet/minecraft/entity/player/EntityPlayer;
```