### PR TITLE
Revert "Enable FOV change when sprinting while still limiting extreme values"

### DIFF
--- a/src/main/java/net/machinemuse/numina/basemod/NuminaConfig.java
+++ b/src/main/java/net/machinemuse/numina/basemod/NuminaConfig.java
@@ -41,7 +41,7 @@ public final class NuminaConfig {
     }
 
     public static boolean useFOVFix() {
-        return getConfigBoolean(Configuration.CATEGORY_GENERAL, "Limit FOV", true);
+        return getConfigBoolean(Configuration.CATEGORY_GENERAL, "Ignore speed boosts for field of view", true);
     }
 
     public static boolean isDebugging() {

--- a/src/main/java/net/machinemuse/numina/event/FOVUpdateEventHandler.java
+++ b/src/main/java/net/machinemuse/numina/event/FOVUpdateEventHandler.java
@@ -9,22 +9,17 @@ import net.minecraftforge.client.event.FOVUpdateEvent;
 /**
  * Author: MachineMuse (Claire Semple)
  * Created: 10:07 PM, 10/17/13
- * <p>
+ *
  * Ported to Java by lehjr on 10/10/16.
  */
 public class FOVUpdateEventHandler {
-
-	@SubscribeEvent
-	public void onFOVUpdate(FOVUpdateEvent e) {
-		if (NuminaConfig.useFOVFix()) {
-			IAttributeInstance attributeinstance = e.entity.getEntityAttribute(SharedMonsterAttributes.movementSpeed);
-			e.newfov = (float) (e.fov / ((attributeinstance.getAttributeValue() / e.entity.capabilities.getWalkSpeed() + 1.0) / 2.0));
-			if (e.entity.isSprinting()) {
-				e.newfov += 0.15F;
-			}
-		}
-	}
-
+    @SubscribeEvent
+    public void onFOVUpdate(FOVUpdateEvent e) {
+        if (NuminaConfig.useFOVFix()) {
+            IAttributeInstance attributeinstance = e.entity.getEntityAttribute(SharedMonsterAttributes.movementSpeed);
+            e.newfov = (float) (e.fov / ((attributeinstance.getAttributeValue() / e.entity.capabilities.getWalkSpeed() + 1.0) / 2.0));
+        }
+    }
 }
 
 


### PR DESCRIPTION
Reverts MachineMuse/Numina#24

defeats the entire purpose of the FOV handler. 